### PR TITLE
Use @metamask/eslint-config@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {},
   "devDependencies": {
     "@metamask/detect-provider": "^1.1.0",
-    "@metamask/eslint-config": "^3.0.0",
+    "@metamask/eslint-config": "^3.1.0",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.1.0",
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,10 +28,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/detect-provider/-/detect-provider-1.1.0.tgz#3200883de5d739bd0f7edfd1c9bb2bd01011ea49"
   integrity sha512-7klN00NjDWPNUG4m5chX7LwUgnQ/L1r1m2+5VNx4zJsbD7oXsqQtkFyGwXe3msYUIvuRFeyH2kK94zeNEidxpw==
 
-"@metamask/eslint-config@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.0.0.tgz#39c4275e440cfc690524d328a0bda8227bd69326"
-  integrity sha512-AYnNopj+K0YyWuCXY4mflgMQzIcm/Jc+HiXzBzY8SJ3fMlnBXjQjsbu0B78zxLR9HZ2uW9IrCj0VG7hMj1b4og==
+"@metamask/eslint-config@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.1.0.tgz#8412ddd3f660748598902fd8dbef6fadc060f25e"
+  integrity sha512-He/zV0Cb5W421mEQveaqSegLarONJbJPReJppQkwhi239PCE7j+6eRji/j2Unwq8TBuOlgQtqL49+dtvks+lPQ==
 
 "@rollup/plugin-commonjs@^13.0.0":
   version "13.0.0"


### PR DESCRIPTION
This PR updates the `@metamask/eslint-config` dependency to the latest published version, v3.1.0.