### PR TITLE
Add lazy provider access

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "homepage": "https://github.com/MetaMask/legacy-web3#readme",
   "dependencies": {},
   "devDependencies": {
-    "@metamask/detect-provider": "^1.2.0",
     "@metamask/eslint-config": "^3.1.0",
     "@rollup/plugin-commonjs": "^13.0.0",
     "@rollup/plugin-node-resolve": "^8.1.0",

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -1,5 +1,4 @@
 require('web3/dist/web3.min.js')
-const detectEthereumProvider = require('@metamask/detect-provider')
 
 const getMessage = (message) => `@metamask/legacy-web3 - ${message}`
 const getExitMessage = (message) => `${getMessage(message)} Exiting without initializing window.web3.`

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -54,7 +54,19 @@ function setupWeb3 () {
       window.ethereum.autoRefreshOnNetworkChange = true
     }
 
-    const web3 = new Web3(window.ethereum)
+    /*
+     * We now construct a lazy provider in case this script is run before the ethereum provider is injected.
+     * This can happen either because this script is run in a different extension for backwards-compat,
+     * or because the provider is being injected late for another reason (platform specific).
+     */
+    const lazyProvider = new Proxy(window.ethereum, {
+      get: function(target, prop, receiver) {
+        return Reflect.get(window.ethereum, prop, receiver);
+      }
+    })
+
+    const web3 = new Web3(lazyProvider)
+
     web3.setProvider = function () {
       console.log(getMessage('Overrode web3.setProvider.'))
     }

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -11,135 +11,113 @@ setupWeb3()
  */
 function setupWeb3 () {
 
-  if (window.ethereum) {
-    _setupWeb3()
-  } else {
-    detectEthereumProvider({ silent: true })
-      .then((_provider) => {
-        if (window.ethereum) {
-          _setupWeb3()
-        } else {
-          console.log(getExitMessage('Failed to detect window.ethereum.'))
-        }
-      })
-      .catch((error) => {
-        console.error(
-          getExitMessage('Unexpected error when detecting window.ethereum.'),
-          error,
-        )
-      })
+  // if used before MetaMask stops injecting window.web3
+  if (window.ethereum && window.ethereum.isMetaMask && window.web3) {
+    console.log(getExitMessage('Detected MetaMask-injected window.web3.'))
+    return
   }
 
-  function _setupWeb3 () {
+  if (window.web3) {
+    console.log(getExitMessage('Detected existing window.web3.'))
+    return
+  }
 
-    // if used before MetaMask stops injecting window.web3
-    if (window.ethereum && window.ethereum.isMetaMask && window.web3) {
-      console.log(getExitMessage('Detected MetaMask-injected window.web3.'))
+  if (window.ethereum && !window.ethereum.isMetaMask) {
+    console.warn(getMessage(
+      'Detected non-MetaMask window.ethereum. ' +
+      'Proceeding to initialize window.web3, but may experience undefined behavior.',
+    ))
+  }
+
+  if (!('autoRefreshOnNetworkChange' in window.ethereum)) {
+    window.ethereum.autoRefreshOnNetworkChange = true
+  }
+
+  /*
+   * We now construct a lazy provider in case this script is run before the ethereum provider is injected.
+   * This can happen either because this script is run in a different extension for backwards-compat,
+   * or because the provider is being injected late for another reason (platform specific).
+   */
+  const lazyProvider = new Proxy({}, {
+    get (_target, prop, receiver) {
+      return Reflect.get(window.ethereum, prop, receiver)
+    },
+  })
+
+  const web3 = new Web3(lazyProvider)
+
+  web3.setProvider = function () {
+    console.log(getMessage('Overrode web3.setProvider.'))
+  }
+  console.log(getMessage('Injected web3.'))
+
+  window.ethereum.on('accountsChanged', (accounts) => {
+    web3.eth.defaultAccount = Array.isArray(accounts) && accounts.length > 0
+      ? accounts[0]
+      : null
+  })
+
+  // export web3 as a global, checking for usage
+  let reloadInProgress = false
+  let lastTimeUsed
+  let previousChainId
+
+  const web3Proxy = new Proxy(web3, {
+    get: (_web3, key) => {
+      // get the time of use
+      lastTimeUsed = Date.now()
+      // return value normally
+      return _web3[key]
+    },
+    set: (_web3, key, value) => {
+      // set value normally
+      _web3[key] = value
+    },
+  })
+
+  Object.defineProperty(window, 'web3', {
+    enumerable: false,
+    writable: true,
+    configurable: true,
+    value: web3Proxy,
+  })
+
+  window.ethereum.on('chainChanged', (currentChainId) => {
+    // if the auto refresh on network change is false do not
+    // do anything
+    if (!window.ethereum.autoRefreshOnNetworkChange) {
       return
     }
 
-    if (window.web3) {
-      console.log(getExitMessage('Detected existing window.web3.'))
+    // if reload in progress, no need to check reload logic
+    if (reloadInProgress) {
       return
     }
 
-    if (window.ethereum && !window.ethereum.isMetaMask) {
-      console.warn(getMessage(
-        'Detected non-MetaMask window.ethereum. ' +
-        'Proceeding to initialize window.web3, but may experience undefined behavior.',
-      ))
+    // set the initial chain
+    if (!previousChainId) {
+      previousChainId = currentChainId
+      return
     }
 
-    if (!('autoRefreshOnNetworkChange' in window.ethereum)) {
-      window.ethereum.autoRefreshOnNetworkChange = true
+    // skip reload logic if web3 not used
+    if (!lastTimeUsed) {
+      return
     }
 
-    /*
-     * We now construct a lazy provider in case this script is run before the ethereum provider is injected.
-     * This can happen either because this script is run in a different extension for backwards-compat,
-     * or because the provider is being injected late for another reason (platform specific).
-     */
-    const lazyProvider = new Proxy(window.ethereum, {
-      get (_target, prop, receiver) {
-        return Reflect.get(window.ethereum, prop, receiver)
-      },
-    })
-
-    const web3 = new Web3(lazyProvider)
-
-    web3.setProvider = function () {
-      console.log(getMessage('Overrode web3.setProvider.'))
+    // if chain did not change, exit
+    if (currentChainId === previousChainId) {
+      return
     }
-    console.log(getMessage('Injected web3.'))
 
-    window.ethereum.on('accountsChanged', (accounts) => {
-      web3.eth.defaultAccount = Array.isArray(accounts) && accounts.length > 0
-        ? accounts[0]
-        : null
-    })
-
-    // export web3 as a global, checking for usage
-    let reloadInProgress = false
-    let lastTimeUsed
-    let previousChainId
-
-    const web3Proxy = new Proxy(web3, {
-      get: (_web3, key) => {
-        // get the time of use
-        lastTimeUsed = Date.now()
-        // return value normally
-        return _web3[key]
-      },
-      set: (_web3, key, value) => {
-        // set value normally
-        _web3[key] = value
-      },
-    })
-
-    Object.defineProperty(window, 'web3', {
-      enumerable: false,
-      writable: true,
-      configurable: true,
-      value: web3Proxy,
-    })
-
-    window.ethereum.on('chainChanged', (currentChainId) => {
-      // if the auto refresh on network change is false do not
-      // do anything
-      if (!window.ethereum.autoRefreshOnNetworkChange) {
-        return
-      }
-
-      // if reload in progress, no need to check reload logic
-      if (reloadInProgress) {
-        return
-      }
-
-      // set the initial chain
-      if (!previousChainId) {
-        previousChainId = currentChainId
-        return
-      }
-
-      // skip reload logic if web3 not used
-      if (!lastTimeUsed) {
-        return
-      }
-
-      // if chain did not change, exit
-      if (currentChainId === previousChainId) {
-        return
-      }
-
-      // initiate page reload
-      reloadInProgress = true
-      const timeSinceUse = Date.now() - lastTimeUsed
-      // if web3 was recently used then delay the reloading of the page
-      if (timeSinceUse > 500) {
-        window.location.reload()
-      } else {
-        setTimeout(window.location.reload, 500)
-      }
-    })
-  }
+    // initiate page reload
+    reloadInProgress = true
+    const timeSinceUse = Date.now() - lastTimeUsed
+    // if web3 was recently used then delay the reloading of the page
+    if (timeSinceUse > 500) {
+      window.location.reload()
+    } else {
+      setTimeout(window.location.reload, 500)
+    }
+  })
 }

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -60,9 +60,9 @@ function setupWeb3 () {
      * or because the provider is being injected late for another reason (platform specific).
      */
     const lazyProvider = new Proxy(window.ethereum, {
-      get: function(target, prop, receiver) {
-        return Reflect.get(window.ethereum, prop, receiver);
-      }
+      get (_target, prop, receiver) {
+        return Reflect.get(window.ethereum, prop, receiver)
+      },
     })
 
     const web3 = new Web3(lazyProvider)

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -41,14 +41,35 @@ function setupWeb3 () {
     get (_target, prop, receiver) {
       return Reflect.get(window.ethereum, prop, receiver)
     },
+    set (_target, sKey, vValue) {
+      return Reflect.set(window.ethereum, sKey, vValue)
+    },
+    deleteProperty (_target, sKey) {
+      return Reflect.deleteProperty(window.ethereum, sKey)
+    },
+    enumerate (_target, sKey) {
+      return Object.keys(window.ethereum)
+    },
+    ownKeys (_target, sKey) {
+      return Reflect.ownKeys(window.ethereum)
+    },
+    has (_target, sKey) {
+      return Reflect.has(window.ethereum, sKey)
+    },
+    defineProperty (_target, sKey, oDesc) {
+      return Reflect.defineProperty(window.ethereum, oKey, oDesc)
+    },
+    getOwnPropertyDescriptor (_target, sKey) {
+      return Reflect.getOwnPropertyDescriptor(window.ethereum, sKey)
+    },
   })
 
   const web3 = new Web3(lazyProvider)
 
   web3.setProvider = function () {
-    console.log(getMessage('Overrode web3.setProvider.'))
+    console.warn(getMessage('Overrode web3.setProvider.'))
   }
-  console.log(getMessage('Injected web3.'))
+  console.log(getMessage('Injected web3.js'))
 
   // update the default account when the revealed accounts change
   window.ethereum.on('accountsChanged', (accounts) => {

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -50,6 +50,7 @@ function setupWeb3 () {
   }
   console.log(getMessage('Injected web3.'))
 
+  // update the default account when the revealed accounts change
   window.ethereum.on('accountsChanged', (accounts) => {
     web3.eth.defaultAccount = Array.isArray(accounts) && accounts.length > 0
       ? accounts[0]

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -105,7 +105,7 @@ function setupWeb3 () {
       return
     }
 
-    // if chain did not change, exit
+    // if chain did not change, skip reload
     if (currentChainId === previousChainId) {
       return
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,11 +23,6 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@metamask/detect-provider@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@metamask/detect-provider/-/detect-provider-1.2.0.tgz#3667a7531f2a682e3c3a43eaf3a1958bdb42a696"
-  integrity sha512-ocA76vt+8D0thgXZ7LxFPyqw3H7988qblgzddTDA6B8a/yU0uKV42QR/DhA+Jh11rJjxW0jKvwb5htA6krNZDQ==
-
 "@metamask/eslint-config@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-3.1.0.tgz#8412ddd3f660748598902fd8dbef6fadc060f25e"


### PR DESCRIPTION
Mostly motivated by the desire to use this library within a
legacy-dapp-support extension, which needs to support the case where
this script could be run before the provider-providing extension (like
MetaMask) is run.

In that case, the web3 returned by this script needs to _lazily_ access
its provider, and so rather than pass it a provider directly, I'm now
constructing it with a Proxy that only accesses the global provider on a
per-access basis.