### PR TITLE
Add MetaMask identifier check

### DIFF
--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -38,7 +38,9 @@ function setupWeb3 () {
       return
     }
 
-    if (window.web3) {
+    // MetaMask will continue to inject a web3 Proxy, with this hidden
+    // identifier
+    if (window.web3 && !window.web3['__isMetaMaskProxy__']) {
       console.log(getExitMessage('Detected existing window.web3.'))
       return
     }

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -40,7 +40,7 @@ function setupWeb3 () {
 
     // MetaMask will continue to inject a web3 Proxy, with this hidden
     // identifier
-    if (window.web3 && !window.web3['__isMetaMaskProxy__']) {
+    if (window.web3 && !window.web3.__isMetaMaskProxy__) {
       console.log(getExitMessage('Detected existing window.web3.'))
       return
     }

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -40,7 +40,7 @@ function setupWeb3 () {
 
     // MetaMask will continue to inject a web3 Proxy, with this hidden
     // identifier
-    if (window.web3 && !window.web3.__isMetaMaskProxy__) {
+    if (window.web3 && !window.web3.__isMetaMaskShim__) {
       console.log(getExitMessage('Detected existing window.web3.'))
       return
     }


### PR DESCRIPTION
We're going to continue injecting a `window.web3` Proxy with just `currentProvider` set. This PR adds a check for a MetaMask identifier that will be present on that Proxy, so that we know to overwrite it.