### PR TITLE
Set web3.eth.defaultAccount on initialization

### DIFF
--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -73,7 +73,7 @@ function setupWeb3 () {
     } else {
       const req = { method: 'eth_accounts' }
 
-      if (typeof ethereum.request === 'function') {
+      if (typeof window.ethereum.request === 'function') {
         window.ethereum.request(req)
           .then(handleAccounts)
           .catch(() => undefined)

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -71,14 +71,19 @@ function setupWeb3 () {
     if (window.ethereum.selectedAddress) {
       web3.eth.defaultAccount = window.ethereum.selectedAddress
     } else {
-      window.ethereum.sendAsync(
-        { method: 'eth_accounts' },
-        (error, response) => {
+      const req = { method: 'eth_accounts' }
+
+      if (typeof ethereum.request === 'function') {
+        window.ethereum.request(req)
+          .then(handleAccounts)
+          .catch(() => undefined)
+      } else {
+        window.ethereum.sendAsync(req, (error, response) => {
           if (!error && response) {
             handleAccounts(response.result)
           }
-        },
-      )
+        })
+      }
     }
     window.ethereum.on('accountsChanged', handleAccounts)
 

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -62,11 +62,25 @@ function setupWeb3 () {
     }
     console.log(getMessage('Injected web3.'))
 
-    window.ethereum.on('accountsChanged', (accounts) => {
+    const handleAccounts = (accounts) => {
       web3.eth.defaultAccount = Array.isArray(accounts) && accounts.length > 0
         ? accounts[0]
         : null
-    })
+    }
+
+    if (window.ethereum.selectedAddress) {
+      web3.eth.defaultAccount = window.ethereum.selectedAddress
+    } else {
+      window.ethereum.sendAsync(
+        { method: 'eth_accounts' },
+        (error, response) => {
+          if (!error && response) {
+            handleAccounts(response.result)
+          }
+        },
+      )
+    }
+    window.ethereum.on('accountsChanged', handleAccounts)
 
     // export web3 as a global, checking for usage
     let reloadInProgress = false


### PR DESCRIPTION
As written, the extension-injected `window.web3` _may_ set `web3.eth.defaultAccount` in cases where this package will not, specifically on initialization. This PR ensures that this package attempts to set `web3.eth.defaultAccount` on initialization, as well as on `accountsChanged` events.