### PR TITLE
Ship unminified code

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ As a `<script>` in your web page:
   <head>
     <!-- The legacy-web3 script must run BEFORE your other scripts. -->
     <script src="https://unpkg.com/@metamask/legacy-web3@latest/dist/metamask.web3.min.js"></script>
+    <!-- Or: -->
+    <script src="https://unpkg.com/@metamask/legacy-web3@latest/dist/metamask.web3.js"></script>
     ...
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "files": [
     "dist/*.js"
   ],
-  "main": "dist/index.js",
+  "main": "dist/metamask.web3.js",
   "scripts": {
     "build": "mkdir -p dist && rm -rf dist/* && rollup -c",
     "lint": "eslint . --ext js,json",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ module.exports = {
       ],
     },
     {
-      file: 'dist/index.js',
+      file: 'dist/metamask.web3.js',
       format: 'umd',
     },
   ],

--- a/src/web3Wrapper.js
+++ b/src/web3Wrapper.js
@@ -1,4 +1,4 @@
-require('web3/dist/web3.min.js')
+require('web3/dist/web3.js')
 const detectEthereumProvider = require('@metamask/detect-provider')
 
 const getMessage = (message) => `@metamask/legacy-web3 - ${message}`


### PR DESCRIPTION
Updates build process to ship unminified in addition to minified version of the package and its dependencies.

The main entry file was previously named `index.js` and partially unminified. It is now renamed to `metamask.web3.js` and wholly unminified.